### PR TITLE
Version 0.4.0

### DIFF
--- a/chord_lib/search/data_structure.py
+++ b/chord_lib/search/data_structure.py
@@ -113,7 +113,7 @@ def _collect_array_lengths(ast: AST, data_structure: QueryableStructure, schema:
 
     # If the current expression is a non-resolve function, recurse into its arguments and collect any additional array
     # accesses; construct a list of possibly redundant array accesses with the arrays' lengths.
-    als = list(chain.from_iterable(_collect_array_lengths(e, data_structure, schema) for e in ast.args))
+    als = tuple(chain.from_iterable(_collect_array_lengths(e, data_structure, schema) for e in ast.args))
     yield from (
         a1 for i1, a1 in enumerate(als)
         if not any(
@@ -225,6 +225,17 @@ def _binary_op(op: BBOperator)\
         # override it with a custom-message type error.
 
         lhs = evaluate(args[0], ds, schema, ic, internal, validate=False)
+
+        # TODO: These shortcuts don't type-check the RHS, is that OK?
+
+        # Shortcut #and
+        if op == and_ and not lhs:
+            return False
+
+        # Shortcut #or
+        if op == or_ and lhs:
+            return True
+
         rhs = evaluate(args[1], ds, schema, ic, internal, validate=False)
 
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pytest==5.3.5
 pytest-cov==2.8.1
 pytest-django==3.8.0
 python-dateutil==2.8.1
-redis>=3.3,<4.0
+redis>=3.4.1,<4.0
 Werkzeug>=1.0,<2.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as rf:
 
 setuptools.setup(
     name="chord_lib",
-    version="0.3.0",
+    version="0.4.0",
 
     python_requires=">=3.6",
     install_requires=["jsonschema>=3.2.0,<4", "psycopg2-binary>=2.7,<3.0", "redis>=3.4.1,<4.0", "Werkzeug>=1.0,<2.0"],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     version="0.3.0",
 
     python_requires=">=3.6",
-    install_requires=["jsonschema>=3.2.0,<4", "psycopg2-binary>=2.7,<3.0", "redis>=3.3,<4.0", "Werkzeug>=1.0,<2.0"],
+    install_requires=["jsonschema>=3.2.0,<4", "psycopg2-binary>=2.7,<3.0", "redis>=3.4.1,<4.0", "Werkzeug>=1.0,<2.0"],
     extras_require={
         "flask": ["Flask>=1.1,<2.0"],
         "django": ["Django>=2.2,<3.0", "djangorestframework>=3.10,<3.11"]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,12 @@ setuptools.setup(
     version="0.4.0",
 
     python_requires=">=3.6",
-    install_requires=["jsonschema>=3.2.0,<4", "psycopg2-binary>=2.7,<3.0", "redis>=3.4.1,<4.0", "Werkzeug>=1.0,<2.0"],
+    install_requires=[
+        "jsonschema>=3.2.0,<4",
+        "psycopg2-binary>=2.8.4,<3.0",
+        "redis>=3.4.1,<4.0",
+        "Werkzeug>=1.0,<2.0",
+    ],
     extras_require={
         "flask": ["Flask>=1.1,<2.0"],
         "django": ["Django>=2.2,<3.0", "djangorestframework>=3.10,<3.11"]


### PR DESCRIPTION
* Bump minimum `redis-py` version to 3.4.1
* Add early return functionality for `#and` and `#or` query functions